### PR TITLE
added polyfill to fix Microsoft Edge script error

### DIFF
--- a/package/gluon-status-page/src/index.html.m4
+++ b/package/gluon-status-page/src/index.html.m4
@@ -9,7 +9,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/event-source-polyfill/0.0.7/eventsource.min.js"></script> <!-- polyfill -->
     <script>
       var bootstrapUrl = "/cgi-bin/nodeinfo";
-      
+
       undivert(app.js)
     </script>
   </head>

--- a/package/gluon-status-page/src/index.html.m4
+++ b/package/gluon-status-page/src/index.html.m4
@@ -6,6 +6,7 @@
     <style>
     undivert(style.css)
     </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/event-source-polyfill/0.0.7/eventsource.min.js</script> <!-- polyfill -->
     <script>
       var bootstrapUrl = "/cgi-bin/nodeinfo";
 

--- a/package/gluon-status-page/src/index.html.m4
+++ b/package/gluon-status-page/src/index.html.m4
@@ -6,10 +6,10 @@
     <style>
     undivert(style.css)
     </style>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/event-source-polyfill/0.0.7/eventsource.min.js</script> <!-- polyfill -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/event-source-polyfill/0.0.7/eventsource.min.js"></script> <!-- polyfill -->
     <script>
       var bootstrapUrl = "/cgi-bin/nodeinfo";
-
+      
       undivert(app.js)
     </script>
   </head>


### PR DESCRIPTION
MS Edge did not work with info page, because on missing EventSource in JavaScript core. So we need to add a polyfill for that.

https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/104894/