### PR TITLE
Revert "generic: batman-adv: disable multicast optimizations for now"

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -40,8 +40,6 @@ config '# CONFIG_PACKAGE_kmod-jool is not set' -- fails to build
 config 'CONFIG_BUSYBOX_CUSTOM=y'
 config '# CONFIG_BUSYBOX_CONFIG_FEATURE_PREFER_IPV4_ADDRESS is not set'
 
-config '# CONFIG_BATMAN_ADV_MCAST is not set'
-
 config 'CONFIG_PACKAGE_ATH_DEBUG=y'
 
 if env.GLUON_TARGET ~= 'ramips-rt305x' and env.GLUON_TARGET ~= 'ar71xx-tiny' then


### PR DESCRIPTION
This reverts commit 819758f4250af8820851945ba1a6c17748b0ab4b.

A proper fix is now available, therefore reverting this workaround.

---

Initially the batman-adv multicast TT entries were disabled due to multicast TT request storms which Freifunk Vogtland experienced in 2017 and in a slight variation at Freifunk Hannover in 2018. These two particular issues were fixed in batman-adv v2017.3 and v2018.2 (382d020f, beb6246b and c7054ffa in particular).

As Freifunk Hannover had confirmed that those patches fixed the issue for them and as no more issues were reported after those fixes by any other communities, batman-adv multicast TT was reenabled in Gluon v2018.1 and stayed enabled since then.

Therefore it seems safe to reenable it for Freifunk Vogtland now, too.

Full list of multicast TT related fixes in batman-adv with their batman-adv release version:


```c7054ffa batman-adv: Fix multicast TT issues with bogus ROAM flags (v2018.2)
beb6246b batman-adv: Avoid storing non-TT-sync flags on singular entries too (v2018.2)
d65daee8 batman-adv: Fix TT sync flags for intermediate TT responses (v2018.2)
49b2132f batman-adv: fix packet loss for broadcasted DHCP packets to a server (v2018.1)
67a50c93 batman-adv: fix multicast-via-unicast transmission with AP isolation (v2018.1)
edba00d5 batman-adv: Fix multicast packet loss with a single WANT_ALL_IPV4/6 flag (v2018.1)
382d020f batman-adv: fix TT sync flag inconsistencies (v2017.3)```