### PR TITLE
Backport for Xiaomi Mi Rotuer 4A Gigabit

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -156,6 +156,9 @@ local primary_addrs = {
 		{'ramips', 'mt7620', {
 			'miwifi-mini',
 		}},
+		{'ramips', 'mt7621', {
+			'xiaomi,mi-router-4a-gigabit',
+		}},
 	}},
 	{phy(1), {
 		{'ar71xx', 'generic', {

--- a/patches/openwrt/0033-Backport-Xiaomi-Mi-Router-4A-Gigabit.patch
+++ b/patches/openwrt/0033-Backport-Xiaomi-Mi-Router-4A-Gigabit.patch
@@ -1,5 +1,5 @@
 From: altima <mail@enricomeinel.de>
-Date: Thu, 7 Jul 2022 18:00:06 +0200
+Date: Thu, 7 Jul 2022 21:00:03 +0200
 Subject: Backport Xiaomi Mi Router 4A Gigabit
 
 diff --git a/package/boot/uboot-envtools/files/ramips b/package/boot/uboot-envtools/files/ramips
@@ -701,3 +701,350 @@ index 28ae0d451fb0ac4dfd6a1a3d30da49587c326553..29785f9792b56d800fd1693ec6e354d4
  define Device/mt7621
    DTS := MT7621
    BLOCKSIZE := 64k
+diff --git a/target/linux/ramips/patches-4.14/0620-net-add-support-for-threaded-NAPI-polling.patch b/target/linux/ramips/patches-4.14/0620-net-add-support-for-threaded-NAPI-polling.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..80bd27dea76cc932cb49eef9416a1872d3d6c77c
+--- /dev/null
++++ b/target/linux/ramips/patches-4.14/0620-net-add-support-for-threaded-NAPI-polling.patch
+@@ -0,0 +1,340 @@
++From: Felix Fietkau <nbd@nbd.name>
++Date: Sun, 26 Jul 2020 14:03:21 +0200
++Subject: [PATCH] net: add support for threaded NAPI polling
++
++For some drivers (especially 802.11 drivers), doing a lot of work in the NAPI
++poll function does not perform well. Since NAPI poll is bound to the CPU it
++was scheduled from, we can easily end up with a few very busy CPUs spending
++most of their time in softirq/ksoftirqd and some idle ones.
++
++Introduce threaded NAPI for such drivers based on a workqueue. The API is the
++same except for using netif_threaded_napi_add instead of netif_napi_add.
++
++In my tests with mt76 on MT7621 using threaded NAPI + a thread for tx scheduling
++improves LAN->WLAN bridging throughput by 10-50%. Throughput without threaded
++NAPI is wildly inconsistent, depending on the CPU that runs the tx scheduling
++thread.
++
++With threaded NAPI it seems stable and consistent (and higher than the best
++results I got without it).
++
++Based on a patch by Hillf Danton
++
++Cc: Hillf Danton <hdanton@sina.com>
++Signed-off-by: Felix Fietkau <nbd@nbd.name>
++---
++
++--- a/include/linux/netdevice.h
+++++ b/include/linux/netdevice.h
++@@ -327,6 +327,7 @@ struct napi_struct {
++ 	struct list_head	dev_list;
++ 	struct hlist_node	napi_hash_node;
++ 	unsigned int		napi_id;
+++	struct work_struct	work;
++ };
++ 
++ enum {
++@@ -337,6 +338,7 @@ enum {
++ 	NAPI_STATE_HASHED,	/* In NAPI hash (busy polling possible) */
++ 	NAPI_STATE_NO_BUSY_POLL,/* Do not add in napi_hash, no busy polling */
++ 	NAPI_STATE_IN_BUSY_POLL,/* sk_busy_loop() owns this NAPI */
+++	NAPI_STATE_THREADED,	/* Use threaded NAPI */
++ };
++ 
++ enum {
++@@ -347,6 +349,7 @@ enum {
++ 	NAPIF_STATE_HASHED	 = BIT(NAPI_STATE_HASHED),
++ 	NAPIF_STATE_NO_BUSY_POLL = BIT(NAPI_STATE_NO_BUSY_POLL),
++ 	NAPIF_STATE_IN_BUSY_POLL = BIT(NAPI_STATE_IN_BUSY_POLL),
+++	NAPIF_STATE_THREADED	 = BIT(NAPI_STATE_THREADED),
++ };
++ 
++ enum gro_result {
++@@ -2094,6 +2097,26 @@ void netif_napi_add(struct net_device *d
++ 		    int (*poll)(struct napi_struct *, int), int weight);
++ 
++ /**
+++ *	netif_threaded_napi_add - initialize a NAPI context
+++ *	@dev:  network device
+++ *	@napi: NAPI context
+++ *	@poll: polling function
+++ *	@weight: default weight
+++ *
+++ * This variant of netif_napi_add() should be used from drivers using NAPI
+++ * with CPU intensive poll functions.
+++ * This will schedule polling from a high priority workqueue
+++ */
+++static inline void netif_threaded_napi_add(struct net_device *dev,
+++					   struct napi_struct *napi,
+++					   int (*poll)(struct napi_struct *, int),
+++					   int weight)
+++{
+++	set_bit(NAPI_STATE_THREADED, &napi->state);
+++	netif_napi_add(dev, napi, poll, weight);
+++}
+++
+++/**
++  *	netif_tx_napi_add - initialize a NAPI context
++  *	@dev:  network device
++  *	@napi: NAPI context
++--- a/net/core/dev.c
+++++ b/net/core/dev.c
++@@ -160,6 +160,7 @@ static DEFINE_SPINLOCK(offload_lock);
++ struct list_head ptype_base[PTYPE_HASH_SIZE] __read_mostly;
++ struct list_head ptype_all __read_mostly;	/* Taps */
++ static struct list_head offload_base __read_mostly;
+++static struct workqueue_struct *napi_workq __read_mostly;
++ 
++ static int netif_rx_internal(struct sk_buff *skb);
++ static int call_netdevice_notifiers_info(unsigned long val,
++@@ -5237,6 +5238,11 @@ void __napi_schedule(struct napi_struct
++ {
++ 	unsigned long flags;
++ 
+++	if (test_bit(NAPI_STATE_THREADED, &n->state)) {
+++		queue_work(napi_workq, &n->work);
+++		return;
+++	}
+++
++ 	local_irq_save(flags);
++ 	____napi_schedule(this_cpu_ptr(&softnet_data), n);
++ 	local_irq_restore(flags);
++@@ -5288,6 +5294,11 @@ EXPORT_SYMBOL(napi_schedule_prep);
++  */
++ void __napi_schedule_irqoff(struct napi_struct *n)
++ {
+++	if (test_bit(NAPI_STATE_THREADED, &n->state)) {
+++		queue_work(napi_workq, &n->work);
+++		return;
+++	}
+++
++ 	if (!IS_ENABLED(CONFIG_PREEMPT_RT))
++ 		____napi_schedule(this_cpu_ptr(&softnet_data), n);
++ 	else
++@@ -5528,6 +5539,82 @@ static enum hrtimer_restart napi_watchdo
++ 	return HRTIMER_NORESTART;
++ }
++ 
+++static int __napi_poll(struct napi_struct *n, bool *repoll)
+++{
+++	int work, weight;
+++
+++	weight = n->weight;
+++
+++	/* This NAPI_STATE_SCHED test is for avoiding a race
+++	 * with netpoll's poll_napi().  Only the entity which
+++	 * obtains the lock and sees NAPI_STATE_SCHED set will
+++	 * actually make the ->poll() call.  Therefore we avoid
+++	 * accidentally calling ->poll() when NAPI is not scheduled.
+++	 */
+++	work = 0;
+++	if (test_bit(NAPI_STATE_SCHED, &n->state)) {
+++		work = n->poll(n, weight);
+++		trace_napi_poll(n, work, weight);
+++	}
+++
+++	WARN_ON_ONCE(work > weight);
+++
+++	if (likely(work < weight))
+++		return work;
+++
+++	/* Drivers must not modify the NAPI state if they
+++	 * consume the entire weight.  In such cases this code
+++	 * still "owns" the NAPI instance and therefore can
+++	 * move the instance around on the list at-will.
+++	 */
+++	if (unlikely(napi_disable_pending(n))) {
+++		napi_complete(n);
+++		return work;
+++	}
+++
+++	if (n->gro_list) {
+++		/* flush too old packets
+++		 * If HZ < 1000, flush all packets.
+++		 */
+++		napi_gro_flush(n, HZ >= 1000);
+++	}
+++
+++	*repoll = true;
+++
+++	return work;
+++}
+++
+++static void napi_workfn(struct work_struct *work)
+++{
+++	struct napi_struct *n = container_of(work, struct napi_struct, work);
+++	void *have;
+++
+++	for (;;) {
+++		bool repoll = false;
+++
+++		local_bh_disable();
+++
+++		have = netpoll_poll_lock(n);
+++		__napi_poll(n, &repoll);
+++		netpoll_poll_unlock(have);
+++
+++		local_bh_enable();
+++
+++		if (!repoll)
+++			return;
+++
+++		if (!need_resched())
+++			continue;
+++
+++		/*
+++		 * have to pay for the latency of task switch even if
+++		 * napi is scheduled
+++		 */
+++		queue_work(napi_workq, work);
+++		return;
+++	}
+++}
+++
++ void netif_napi_add(struct net_device *dev, struct napi_struct *napi,
++ 		    int (*poll)(struct napi_struct *, int), int weight)
++ {
++@@ -5546,6 +5633,7 @@ void netif_napi_add(struct net_device *d
++ #ifdef CONFIG_NETPOLL
++ 	napi->poll_owner = -1;
++ #endif
+++	INIT_WORK(&napi->work, napi_workfn);
++ 	set_bit(NAPI_STATE_SCHED, &napi->state);
++ 	set_bit(NAPI_STATE_NPSVC, &napi->state);
++ 	list_add_rcu(&napi->dev_list, &dev->napi_list);
++@@ -5573,6 +5661,7 @@ EXPORT_SYMBOL(napi_disable);
++ void netif_napi_del(struct napi_struct *napi)
++ {
++ 	might_sleep();
+++	cancel_work_sync(&napi->work);
++ 	if (napi_hash_del(napi))
++ 		synchronize_net();
++ 	list_del_init(&napi->dev_list);
++@@ -5586,49 +5675,19 @@ EXPORT_SYMBOL(netif_napi_del);
++ 
++ static int napi_poll(struct napi_struct *n, struct list_head *repoll)
++ {
+++	bool do_repoll = false;
++ 	void *have;
++-	int work, weight;
+++	int work;
++ 
++ 	list_del_init(&n->poll_list);
++ 
++ 	have = netpoll_poll_lock(n);
++ 
++-	weight = n->weight;
+++	work = __napi_poll(n, &do_repoll);
++ 
++-	/* This NAPI_STATE_SCHED test is for avoiding a race
++-	 * with netpoll's poll_napi().  Only the entity which
++-	 * obtains the lock and sees NAPI_STATE_SCHED set will
++-	 * actually make the ->poll() call.  Therefore we avoid
++-	 * accidentally calling ->poll() when NAPI is not scheduled.
++-	 */
++-	work = 0;
++-	if (test_bit(NAPI_STATE_SCHED, &n->state)) {
++-		work = n->poll(n, weight);
++-		trace_napi_poll(n, work, weight);
++-	}
++-
++-	WARN_ON_ONCE(work > weight);
++-
++-	if (likely(work < weight))
+++	if (!do_repoll)
++ 		goto out_unlock;
++ 
++-	/* Drivers must not modify the NAPI state if they
++-	 * consume the entire weight.  In such cases this code
++-	 * still "owns" the NAPI instance and therefore can
++-	 * move the instance around on the list at-will.
++-	 */
++-	if (unlikely(napi_disable_pending(n))) {
++-		napi_complete(n);
++-		goto out_unlock;
++-	}
++-
++-	if (n->gro_list) {
++-		/* flush too old packets
++-		 * If HZ < 1000, flush all packets.
++-		 */
++-		napi_gro_flush(n, HZ >= 1000);
++-	}
++-
++ 	/* Some drivers may have called napi_schedule
++ 	 * prior to exhausting their budget.
++ 	 */
++@@ -8863,6 +8922,10 @@ static int __init net_dev_init(void)
++ 		sd->backlog.weight = weight_p;
++ 	}
++ 
+++	napi_workq = alloc_workqueue("napi_workq", WQ_UNBOUND | WQ_HIGHPRI,
+++				     WQ_UNBOUND_MAX_ACTIVE | WQ_SYSFS);
+++	BUG_ON(!napi_workq);
+++
++ 	dev_boot_phase = 0;
++ 
++ 	/* The loopback device is special if any other network devices
++--- a/net/core/net-sysfs.c
+++++ b/net/core/net-sysfs.c
++@@ -441,6 +441,52 @@ static ssize_t proto_down_store(struct d
++ }
++ NETDEVICE_SHOW_RW(proto_down, fmt_dec);
++ 
+++static int change_napi_threaded(struct net_device *dev, unsigned long val)
+++{
+++	struct napi_struct *napi;
+++
+++	if (list_empty(&dev->napi_list))
+++		return -EOPNOTSUPP;
+++
+++	list_for_each_entry(napi, &dev->napi_list, dev_list) {
+++		if (val)
+++			set_bit(NAPI_STATE_THREADED, &napi->state);
+++		else
+++			clear_bit(NAPI_STATE_THREADED, &napi->state);
+++	}
+++
+++	return 0;
+++}
+++
+++static ssize_t napi_threaded_store(struct device *dev,
+++				struct device_attribute *attr,
+++				const char *buf, size_t len)
+++{
+++	return netdev_store(dev, attr, buf, len, change_napi_threaded);
+++}
+++
+++static ssize_t napi_threaded_show(struct device *dev,
+++				  struct device_attribute *attr,
+++				  char *buf)
+++{
+++	struct net_device *netdev = to_net_dev(dev);
+++	struct napi_struct *napi;
+++	bool enabled = false;
+++
+++	if (!rtnl_trylock())
+++		return restart_syscall();
+++
+++	list_for_each_entry(napi, &netdev->napi_list, dev_list) {
+++		if (test_bit(NAPI_STATE_THREADED, &napi->state))
+++			enabled = true;
+++	}
+++
+++	rtnl_unlock();
+++
+++	return sprintf(buf, fmt_dec, enabled);
+++}
+++static DEVICE_ATTR_RW(napi_threaded);
+++
++ static ssize_t phys_port_id_show(struct device *dev,
++ 				 struct device_attribute *attr, char *buf)
++ {
++@@ -536,6 +582,7 @@ static struct attribute *net_class_attrs
++ 	&dev_attr_flags.attr,
++ 	&dev_attr_tx_queue_len.attr,
++ 	&dev_attr_gro_flush_timeout.attr,
+++	&dev_attr_napi_threaded.attr,
++ 	&dev_attr_phys_port_id.attr,
++ 	&dev_attr_phys_port_name.attr,
++ 	&dev_attr_phys_switch_id.attr,
+\ No newline at end of file

--- a/patches/openwrt/0033-Backport-Xiaomi-Mi-Router-4A-Gigabit.patch
+++ b/patches/openwrt/0033-Backport-Xiaomi-Mi-Router-4A-Gigabit.patch
@@ -1,0 +1,703 @@
+From: altima <mail@enricomeinel.de>
+Date: Thu, 7 Jul 2022 18:00:06 +0200
+Subject: Backport Xiaomi Mi Router 4A Gigabit
+
+diff --git a/package/boot/uboot-envtools/files/ramips b/package/boot/uboot-envtools/files/ramips
+index 01171ead1ccf16dc73ccf2ad5fdb5799a5173fad..3839e261025dea09ea38d137e2988c28fd40f5c0 100644
+--- a/package/boot/uboot-envtools/files/ramips
++++ b/package/boot/uboot-envtools/files/ramips
+@@ -37,6 +37,11 @@ xiaomi,mir3p|\
+ xiaomi,mir3g)
+ 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
+ 	;;
++xiaomi,xiaomi_mi-router-4a-gigabit|\
++xiaomi,mir4ag)
++	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x10000"
++	;;
++
+ esac
+ 
+ config_load ubootenv
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index 8ca1831afe1e99371a6fb1f3cab6aad3107f7775..34cdfc587f5e3c804935a8866423b45bf6a1e4bc 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -310,7 +310,8 @@ ramips_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"4:lan" "6t@eth0"
+ 		;;
+-	cudy,wr1000)
++	cudy,wr1000|
++	xiaomi,mi-router-4a-gigabit)
+ 		ucidef_add_switch "switch0" \
+ 			"2:lan:2" "3:lan:1" "4:wan" "6@eth0"
+ 		;;
+@@ -686,6 +687,10 @@ ramips_setup_macs()
+ 	xiaomi,mir3g|\
+ 	xiaomi,mir3p)
+ 		lan_mac=$(mtd_get_mac_binary Factory 0xe006)
++ 		;;
++	xiaomi,mi-router-4a-gigabit)
++		wan_mac=$(mtd_get_mac_binary factory 0xe006)
++		label_mac=$wan_mac
+ 		;;
+ 	zyxel,keenetic-start)
+ 		wan_mac=$(mtd_get_mac_binary factory 40)
+diff --git a/target/linux/ramips/base-files/sbin/u-boot-upgrade b/target/linux/ramips/base-files/sbin/u-boot-upgrade
+new file mode 100644
+index 0000000000000000000000000000000000000000..0043575a89c3c9bded644cfb0483c139345871da
+--- /dev/null
++++ b/target/linux/ramips/base-files/sbin/u-boot-upgrade
+@@ -0,0 +1,296 @@
++#!/bin/sh
++
++#==================================================
++#      Name: u-boot-upgrade
++#   Purpose: Update U-Boot partition using mtd tool
++#
++#    Author: Piotr Dymacz <piotr@dymacz.pl>
++# Copyright: Copyright (C) 2014 Piotr Dymacz
++#   Created: 2014-11-19
++#==================================================
++
++      MTD_DEVICE="mtd0"
++   NEW_UBOOT_DIR="/etc/u-boot_mod"
++ NEW_UBOOT_FNAME=""
++  MTD_BACKUP_MD5=""
++MTD_BACKUP_FNAME="mtd0_backup.bin"
++
++echo_info() {
++	echo -e "[\e[96minfo\e[0m] $1"
++}
++
++echo_err() {
++	echo -e "[\e[31merro\e[0m] $1"
++}
++
++echo_ok() {
++	echo -e "[\e[92m ok \e[0m] $1"
++}
++
++echo_warn() {
++	echo -e "[\e[93mwarn\e[0m] $1"
++}
++
++wait_for_yesno() {
++	local question="$1"
++
++	echo ""
++	read -p "-----> $question (type 'yes' or 'no')? " answer
++
++	while true; do
++		case "$answer" in
++		"yes")
++			echo ""
++			return 0
++			;;
++		"no")
++			echo ""
++			return 1
++			;;
++		*)
++			read -p "Please, type 'yes' or 'no': " answer
++			;;
++		esac
++	done
++}
++
++show_disclaimer() {
++	echo ""
++	echo "======================================================="
++	echo -ne "\e[93m"
++	echo "DISCLAIMER: you are using this script at your own risk!"
++	echo -ne "\e[0m"
++	echo ""
++	echo "The author of U-Boot modification and this script takes"
++	echo "no responsibility for any of the results of using them."
++	echo ""
++	echo -ne "\e[31m"
++	echo "     Updating U-Boot is a very dangerous operation"
++	echo "   and may damage your device! You have been warned!"
++	echo -ne "\e[0m"
++	echo "======================================================="
++
++	wait_for_yesno "Do you want to continue" || return 1
++}
++
++find_new_uboot_file() {
++	local filesqty=""
++	local new_ubot_md5=""
++
++	[ -d "$NEW_UBOOT_DIR" ] || {
++		echo_err "Directory '$NEW_UBOOT_DIR' does not exist"
++		return 1
++	}
++
++	cd "$NEW_UBOOT_DIR" >/dev/null 2>&1 || {
++		echo_err "Could not change directory to '$NEW_UBOOT_DIR'"
++		return 1
++	}
++
++	filesqty="$(find . -maxdepth 1 -name "*.bin" | wc -l)"
++
++	[ "$filesqty" -eq "0" ] && {
++		echo_err "Could not find any binary file in '$NEW_UBOOT_DIR'"
++		return 1
++	}
++
++	[ "$filesqty" -gt "1" ] && {
++		echo_err "Found more than one binary file in '$NEW_UBOOT_DIR'"
++		return 1
++	}
++
++	NEW_UBOOT_FNAME="$(basename "$(find . -maxdepth 1 -name "*.bin")")"
++	new_ubot_md5="$(basename "$NEW_UBOOT_FNAME" .bin).md5"
++
++	[ -e "$new_ubot_md5" ] || {
++		[ -e "md5sums" ] && \
++		grep -q "$NEW_UBOOT_FNAME" "md5sums" && \
++		grep "$NEW_UBOOT_FNAME" "md5sums" > "$new_ubot_md5" && \
++		echo_info "Checksum file successfully created from 'md5sums'"
++	}
++
++	[ -e "$new_ubot_md5" ] || {
++		echo_err "Checksum file '$new_ubot_md5' does not exist"
++		return 1
++	}
++
++	echo_ok "Found U-Boot image file: '$NEW_UBOOT_FNAME'"
++
++	wait_for_yesno "Do you want to use this file" || return 1
++
++	md5sum -cs "$new_ubot_md5" >/dev/null 2>&1 || {
++		echo_err "MD5 checksum of new U-Boot image file is wrong"
++		return 1
++	}
++
++	echo_ok "MD5 checksum of new U-Boot image file is correct"
++}
++
++backup_mtd_zero() {
++	[ -c "/dev/$MTD_DEVICE" ] || {
++		echo_err "Device /dev/$MTD_DEVICE does not exist"
++		return 1
++	}
++
++	cd /tmp >/dev/null 2>&1 || {
++		echo_err "Could not change directory to '/tmp'"
++		return 1
++	}
++
++	[ -e "$MTD_BACKUP_FNAME" ] && rm -f "$MTD_BACKUP_FNAME" >/dev/null 2>&1
++
++	dd if=/dev/"$MTD_DEVICE" of="$MTD_BACKUP_FNAME" >/dev/null 2>&1 || {
++		echo_err "Could not backup '/dev/$MTD_DEVICE'"
++		return 1
++	}
++
++	MTD_BACKUP_MD5="$(md5sum "$MTD_BACKUP_FNAME" | awk '{print $1}')"
++	[ -n "$MTD_BACKUP_MD5" ] || {
++		echo_err "Could not calculate MD5 of backup file"
++		return 1
++	}
++
++	echo_ok "Backup of /dev/$MTD_DEVICE successfully created"
++
++	wait_for_yesno "Do you want to store backup (recommended) in '$NEW_UBOOT_DIR/backup/'" || return 0
++
++	mkdir -p "$NEW_UBOOT_DIR/backup" >/dev/null 2>&1 || {
++		echo_err "Could not create '$NEW_UBOOT_DIR/backup'"
++		return 1
++	}
++
++	cp -f "$MTD_BACKUP_FNAME" "$NEW_UBOOT_DIR/backup/$MTD_BACKUP_FNAME" >/dev/null 2>&1 || {
++		echo_err "Could not copy backup file '$MTD_BACKUP_FNAME' to '$NEW_UBOOT_DIR/backup/'"
++		return 1
++	}
++
++	echo_ok "Backup of '/dev/$MTD_DEVICE' successfully copied to '$NEW_UBOOT_DIR/backup/'"
++}
++
++check_rw_status() {
++	local mtdrw="kmod-mtd-rw"
++	local rwfalg="0x400"
++	local flags=""
++
++	[ -e "/sys/class/mtd/$MTD_DEVICE/flags" ] || return 0
++
++	flags="$(cat /sys/class/mtd/$MTD_DEVICE/flags)"
++	[ "$((flags & rwfalg))" -gt "0" ] && {
++		echo_info "Partition '/dev/$MTD_DEVICE' is writable"
++		return 0
++	}
++
++	echo_warn "Partition '/dev/$MTD_DEVICE' is not writable"
++
++	opkg list-installed | grep -q "$mtdrw" || {
++		wait_for_yesno "Do you want to install '$mtdrw' and unclock '/dev/$MTD_DEVICE'" || return 1
++
++		echo_info "Updating packages..."
++
++		opkg update > /dev/null 2>&1 || {
++			echo_err "Could not update packages, check your Internet connection"
++			return 1
++		}
++
++		echo_ok "Packages successfully updated, installing '$mtdrw'..."
++
++		opkg install "$mtdrw" > /dev/null 2>&1 || {
++			echo_err "Could not install '$mtdrw' package"
++			return 1
++		}
++
++		echo_ok "Package '$mtdrw' successfully installed"
++	}
++
++	echo_info "Unlocking '/dev/$MTD_DEVICE' partition..."
++
++	insmod mtd-rw i_want_a_brick=1 >/dev/null 2>&1 || {
++		echo_err "Could not load 'mtd-rw' kernel module"
++		return 1
++	}
++
++	flags="$(cat /sys/class/mtd/$MTD_DEVICE/flags)"
++	[ "$((flags & rwfalg))" -gt "0" ] || {
++		echo_err "Could not unlock '/dev/$MTD_DEVICE' partition"
++		return 1
++	}
++
++	echo_ok "Partition '/dev/$MTD_DEVICE' successfully unlocked"
++}
++
++combine_images() {
++	local new_size=""
++	local old_size=""
++
++	new_size="$(wc -c "$NEW_UBOOT_DIR/$NEW_UBOOT_FNAME" | awk '{print $1}')"
++	old_size="$(wc -c "/tmp/$MTD_BACKUP_FNAME" | awk '{print $1}')"
++
++	[ -n "$old_size" ] || [ -n "$new_size" ] || {
++		echo_err "Could not get size of new U-Boot image and/or backup file"
++		return 1
++	}
++
++	# Allow to use only images not bigger than mtd0 size
++	[ "$new_size" -gt "$old_size" ] && {
++		echo_err "New U-Boot image size ('$new_size' bytes) is bigger than '$MTD_DEVICE' partition size ('$old_size' bytes)"
++		return 1
++	}
++
++	dd if="$NEW_UBOOT_DIR/$NEW_UBOOT_FNAME" of="/tmp/$MTD_BACKUP_FNAME" conv=notrunc >/dev/null 2>&1 || {
++		echo_err "Could not combine new U-Boot image with backup file"
++		return 1
++	}
++
++	echo_ok "New U-Boot image successfully combined with backup file"
++}
++
++write_new_image() {
++	local newmd5=""
++
++	echo_info "New U-Boot image is ready to be written into FLASH"
++
++	wait_for_yesno "Do you want to continue" || return 1
++
++	# Erase mtd0 and write new image...
++	mtd -e "/dev/$MTD_DEVICE" write "/tmp/$MTD_BACKUP_FNAME" "/dev/$MTD_DEVICE" >/dev/null 2>&1 || {
++		echo_warn "Could not write new U-Boot image into FLASH"
++
++		newmd5="$(md5sum "/dev/$MTD_DEVICE" | awk '{print $1}')"
++
++		[ "$MTD_BACKUP_MD5" = "$newmd5" ] && {
++			echo_ok "Original '/dev/$MTD_DEVICE' partition content was not changed"
++			return 0
++		}
++
++		echo_err "FATAL ERROR: '/dev/$MTD_DEVICE' and old U-Boot image are not equal"
++		echo_err "DO NOT REBOOT OR POWER DOWN YOUR DEVICE NOW AND TRY AGAIN!"
++		return 1
++	}
++
++	echo_ok "New U-Boot image successfully written into FLASH"
++
++	# Verify MD5 of mtd0 and prepared image
++	mtd verify "/tmp/$MTD_BACKUP_FNAME" "/dev/$MTD_DEVICE" 2>&1 | grep -q "Success" || {
++		echo_err "FATAL ERROR: '/dev/$MTD_DEVICE' and new U-Boot image are not equal"
++		echo_err "DO NOT REBOOT OR POWER DOWN YOUR DEVICE NOW AND TRY AGAIN!"
++		return 1
++	}
++
++	echo_ok "'/dev/$MTD_DEVICE' and new U-Boot image are equal"
++
++	echo_info "Done! You can now reboot your device!"
++	echo ""
++}
++
++#======================
++# Execution begins here
++#======================
++
++show_disclaimer     && \
++find_new_uboot_file && \
++backup_mtd_zero     && \
++check_rw_status     && \
++combine_images      && \
++write_new_image
++
++exit 0
+diff --git a/target/linux/ramips/dts/XIAOMI-MIR4A-GIGABIT.dts b/target/linux/ramips/dts/XIAOMI-MIR4A-GIGABIT.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..2c1b0786fbfe0c30a7d0cad75cdfb3ba7a2148e7
+--- /dev/null
++++ b/target/linux/ramips/dts/XIAOMI-MIR4A-GIGABIT.dts
+@@ -0,0 +1,155 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/dts-v1/;
++
++#include "mt7621.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "xiaomi,mi-router-4a-gigabit", "mediatek,mt7621-soc";
++	model = "Xiaomi Mi Router 4A Gigabit Edition";
++
++	aliases {
++		led-boot = &led_status_yellow;
++		led-failsafe = &led_status_yellow;
++		led-running = &led_status_blue;
++		led-upgrade = &led_status_yellow;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200n8";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_status_blue: status_blue {
++			label = "mi-router-4a-gigabit:blue:status";
++			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
++		};
++
++		led_status_yellow: status_yellow {
++			label = "mi-router-4a-gigabit:yellow:status";
++			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	button {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++	};
++};
++
++&spi0 {
++	status = "okay";
++
++	m25p80@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <50000000>; // Factory is 80mhz, but not all boards can run well!
++		m25p,fast-read;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "flash";
++				reg = <0x0 0x1000000>;
++				compatible = "fixed-partitions";
++				#address-cells = <1>;
++				#size-cells = <1>;
++
++				partition@0 {
++					label = "u-boot";
++					reg = <0x0 0x30000>;
++					read-only;
++				};
++			};
++
++			partition@30000 {
++				label = "u-boot-env";
++				reg = <0x30000 0x10000>;
++			};
++
++			partition@40000 {
++				label = "Bdata";
++				reg = <0x40000 0x10000>;
++				read-only;
++			};
++
++			factory: partition@50000 {
++				label = "factory";
++				reg = <0x50000 0x10000>;
++				read-only;
++			};
++
++			partition@60000 {
++				label = "crash";
++				reg = <0x60000 0x10000>;
++				read-only;
++			};
++
++			partition@70000 {
++				label = "cfg_bak";
++				reg = <0x70000 0x10000>;
++				read-only;
++			};
++
++			partition@80000 {
++				label = "overlay";
++				reg = <0x80000 0x100000>;
++				read-only;
++			};
++
++			firmware: partition@180000 {
++				compatible = "denx,uimage";
++				label = "firmware";
++				reg = <0x180000 0xe80000>;
++			};
++		};
++	};
++};
++
++&pcie {
++	status = "okay";
++};
++
++&pcie0 {
++	wifi@0,0 {
++		compatible = "pci14c3,7662";
++		reg = <0x0000 0 0 0 0>;
++		mediatek,mtd-eeprom = <&factory 0x8000>;
++		ieee80211-freq-limit = <5000000 6000000>;
++	};
++};
++
++&pcie1 {
++	wifi@0,0 {
++		compatible = "pci14c3,7603";
++		reg = <0x0000 0 0 0 0>;
++		mediatek,mtd-eeprom = <&factory 0x0000>;
++		ieee80211-freq-limit = <2400000 2500000>;
++	};
++};
++
++&ethernet {
++	mtd-mac-address = <&factory 0xe000>;
++	mediatek,portmap = "lllwl";
++};
++
++&pinctrl {
++	state_default: pinctrl0 {
++		gpio {
++			ralink,group = "jtag", "uart2", "uart3", "wdt";
++			ralink,function = "gpio";
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
+index 232bcd8cf4ea5edbd34d815032ce72b1f1f85661..e0ba70a0c13948877a5847e24ce4f2de97a08efc 100644
+--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
++++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/gsw_mt7621.c
+@@ -71,7 +71,7 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
+ 	u32 i;
+ 	u32 val;
+ 
+-	/* wardware reset the switch */
++	/* hardware reset the switch */
+ 	fe_reset(RST_CTRL_MCM);
+ 	mdelay(10);
+ 
+@@ -98,10 +98,31 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
+ 	mt7530_mdio_w32(gsw, 0x7000, 0x3);
+ 	usleep_range(10, 20);
+ 
++	/* show switch revision number */
++	pr_info("gsw: chip rev: %u\n", rt_sysc_r32(SYSC_REG_CHIP_REV_ID));
++	
++	/* Disable Flow Control Globally - MT7621 bug */
++	usleep_range(10, 20);
++	val = mt7530_mdio_r32(gsw, 0x1FE0);
++	val &= ~BIT(31);
++	mt7530_mdio_w32(gsw, 0x1FE0, val);
++
++	/* Disable flow control on Port 5 (GMAC) and Port 6 (CPU) */
+ 	/* (GE1, Force 1000M/FD, FC OFF, MAX_RX_LENGTH 1536) */
+ 	mtk_switch_w32(gsw, 0x2305e30b, GSW_REG_MAC_P0_MCR);
+-	mt7530_mdio_w32(gsw, 0x3600, 0x5e30b);
+ 
++	for (i = 5; i <= 6; i++) {
++		mt7530_mdio_w32(gsw, 0x3000 + (i * 0x100), 0x5e30b);
++		usleep_range(10, 20);
++	}
++	
++	/* turn off pause advertisement on all PHYs */
++	for (i = 0; i <= 4; i++) {
++		val = _mt7620_mii_read(gsw, i, 0x04);
++		val &= ~BIT(10);
++		_mt7620_mii_write(gsw, i, 0x04, val);
++	}
++	
+ 	/* (GE2, Link down) */
+ 	mtk_switch_w32(gsw, 0x8000, GSW_REG_MAC_P1_MCR);
+ 
+@@ -180,6 +201,22 @@ static void mt7621_hw_init(struct mt7620_gsw *gsw, struct device_node *np)
+ 	mt7530_mdio_w32(gsw, 0x7a74, 0x44);
+ 	mt7530_mdio_w32(gsw, 0x7a7c, 0x44);
+ 
++	/* Disable EEE */
++	for (i = 0; i <= 4; i++) {
++		_mt7620_mii_write(gsw, i, 13, 0x7);
++		_mt7620_mii_write(gsw, i, 14, 0x3C);
++		_mt7620_mii_write(gsw, i, 13, 0x4007);
++		_mt7620_mii_write(gsw, i, 14, 0x0);
++	}
++
++	/* Disable EEE 10Base-Te */
++	for (i = 0; i <= 4; i++) {
++		_mt7620_mii_write(gsw, i, 13, 0x1f);
++		_mt7620_mii_write(gsw, i, 14, 0x027b);
++		_mt7620_mii_write(gsw, i, 13, 0x401f);
++		_mt7620_mii_write(gsw, i, 14, 0x1177);
++	}
++
+ 	/* turn on all PHYs */
+ 	for (i = 0; i <= 4; i++) {
+ 		val = _mt7620_mii_read(gsw, i, 0);
+diff --git a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+index b2c3d32c5549b6fd8ea4c76dc224b9b4b41130d8..f689bfe9a3618b517fa58b6c0fc3f0c4b17da325 100644
+--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
++++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.c
+@@ -1513,6 +1513,9 @@ static void fe_reset_pending(struct fe_priv *priv)
+ 		dev_close(dev);
+ 	}
+ 	rtnl_unlock();
++
++	if (priv->soc->reset_ports)
++		priv->soc->reset_ports(priv);
+ }
+ 
+ static const struct fe_work_t fe_work[] = {
+@@ -1635,7 +1638,7 @@ static int fe_probe(struct platform_device *pdev)
+ 		priv->tx_ring.tx_ring_size *= 4;
+ 		priv->rx_ring.rx_ring_size *= 4;
+ 	}
+-	netif_napi_add(netdev, &priv->rx_napi, fe_poll, napi_weight);
++	netif_threaded_napi_add(netdev, &priv->rx_napi, fe_poll, napi_weight);
+ 	fe_set_ethtool_ops(netdev);
+ 
+ 	err = register_netdev(netdev);
+diff --git a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.h b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.h
+index 2f6fe1724c8c784d9f6b30ab09918da1f210398d..a9e91b10a54bdd35174fac1c74c7e3e5b890c8dc 100644
+--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.h
++++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/mtk_eth_soc.h
+@@ -392,6 +392,7 @@ struct fe_soc_data {
+ 			  u16 val);
+ 	int (*mdio_read)(struct mii_bus *bus, int phy_addr, int phy_reg);
+ 	void (*mdio_adjust_link)(struct fe_priv *priv, int port);
++	void (*reset_ports)(struct fe_priv *priv);
+ 
+ 	void *swpriv;
+ 	u32 pdma_glo_cfg;
+diff --git a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7621.c b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7621.c
+index 3d2866af3aa9d8c2285d56ab711a7b40c16e68dd..68e599d52e90406e31f8a22f42e87fdce2e17f47 100644
+--- a/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7621.c
++++ b/target/linux/ramips/files-4.14/drivers/net/ethernet/mediatek/soc_mt7621.c
+@@ -16,6 +16,7 @@
+ #include <linux/platform_device.h>
+ #include <linux/if_vlan.h>
+ #include <linux/of_net.h>
++#include <linux/delay.h>
+ 
+ #include <asm/mach-ralink/ralink_regs.h>
+ 
+@@ -158,6 +159,30 @@ static void mt7621_set_mac(struct fe_priv *priv, unsigned char *mac)
+ 	spin_unlock_irqrestore(&priv->page_lock, flags);
+ }
+ 
++static void mt7621_reset_ports(struct fe_priv *priv)
++{
++	struct mt7620_gsw *gsw = priv->soc->swpriv;
++	u8 i;
++	u32 val;
++
++	/* Disable all ports */
++	for (i = 0; i <= 4; i++) {
++		val = _mt7620_mii_read(gsw, i, 0x0);
++		val |= BIT(11);
++		_mt7620_mii_write(gsw, i, 0x0, val);
++	}
++
++	/* Allow ports a (short) time to settle */
++	udelay(1000);
++
++	/* Enable ports */
++	for (i = 0; i <= 4; i++) {
++		val = _mt7620_mii_read(gsw, i, 0);
++		val &= ~BIT(11);
++		_mt7620_mii_write(gsw, i, 0, val);
++	}
++}
++
+ static struct fe_soc_data mt7621_data = {
+ 	.init_data = mt7621_init_data,
+ 	.reset_fe = mt7621_fe_reset,
+@@ -176,6 +201,7 @@ static struct fe_soc_data mt7621_data = {
+ 	.mdio_read = mt7620_mdio_read,
+ 	.mdio_write = mt7620_mdio_write,
+ 	.mdio_adjust_link = mt7620_mdio_link_adjust,
++	.reset_ports = mt7621_reset_ports,
+ };
+ 
+ const struct of_device_id of_fe_match[] = {
+diff --git a/target/linux/ramips/image/mt7621.mk b/target/linux/ramips/image/mt7621.mk
+index 28ae0d451fb0ac4dfd6a1a3d30da49587c326553..29785f9792b56d800fd1693ec6e354d485dee4a7 100644
+--- a/target/linux/ramips/image/mt7621.mk
++++ b/target/linux/ramips/image/mt7621.mk
+@@ -59,6 +59,14 @@ define Build/wr1201-factory-header
+ 		-n 'WR1201_8_128' -d $@ $@.new
+ 	mv $@.new $@
+ endef
++ 
++define Build/mi-router-4a-gigabit-factory-header
++	mkimage -A $(LINUX_KARCH) \
++		-O linux -T kernel \
++		-C lzma -a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
++		-n 'R4A' -d $@ $@.new
++	mv $@.new $@
++endef
+ 
+ define Build/netis-tail
+ 	echo -n $(1) >> $@
+@@ -298,6 +306,19 @@ define Device/xiaomi_mir3g
+ endef
+ TARGET_DEVICES += xiaomi_mir3g
+ 
++define Device/xiaomi_mi-router-4a-gigabit
++  DTS := XIAOMI-MIR4A-GIGABIT
++  MTK_SOC := mt7621
++  IMAGE_SIZE := 14848k
++  DEVICE_VENDOR := Xiaomi
++  DEVICE_TITLE := Xiaomi Mi Router 4A Gigabit Edition
++  DEVICE_VARIANT := Gigabit Edition
++  DEVICE_MODEL := Mi Router 4A
++  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 wpad-basic uboot-envtools
++  DEVICE_COMPAT_VERSION := 1.1
++endef
++TARGET_DEVICES += xiaomi_mi-router-4a-gigabit
++
+ define Device/mt7621
+   DTS := MT7621
+   BLOCKSIZE := 64k

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -25,6 +25,11 @@ device('netgear-wndr3700v5', 'wndr3700v5', {
 	broken = true, -- untested
 })
 
+-- Xiaomi
+
+device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
+	factory = false,
+})
 
 -- ZBT
 


### PR DESCRIPTION
This is teh backport of the Xiaomi Mi Router 4A Gigabit. Backport was done by eulenfunk, Found this in teh Freifunk Community Forum. 

* Source is https://github.com/eulenfunk/firmware/tree/v2021.x/patches -> patches for 4a-giga. 
* Tested with 5 routers. 

Would be enough to have the backport only in the experimental branch. The next gluon version is "almost" ready and will include new hardware as well as the 4A Gigabit.